### PR TITLE
Fix the include for torch_utils

### DIFF
--- a/utils/export_yoloV8_pose.py
+++ b/utils/export_yoloV8_pose.py
@@ -7,7 +7,7 @@ import torch
 import torch.nn as nn
 from copy import deepcopy
 from ultralytics import YOLO
-from ultralytics.yolo.utils.torch_utils import select_device
+from ultralytics.utils.torch_utils import select_device
 from ultralytics.nn.modules import C2f, Detect, RTDETRDecoder
 
 


### PR DESCRIPTION
Fix the `torch_utils` import. Needed for ultralytics version `8.0.200`