### PR TITLE
Fix memory leak

### DIFF
--- a/nvdsinfer_custom_impl_Yolo_pose/nvdsparsepose_Yolo.cpp
+++ b/nvdsinfer_custom_impl_Yolo_pose/nvdsparsepose_Yolo.cpp
@@ -78,6 +78,8 @@ nonMaximumSuppression(std::vector<NvDsInferInstanceMaskInfo> binfo)
     }
     if (keep) {
       out.push_back(i);
+    } else {
+      delete[] i.mask;
     }
   }
   return out;


### PR DESCRIPTION
After executing "nonMaximumSuppression", for all "bbi.mask" allocated in "addPoseProposal", only a few of them which got kept will be freed in "nvinfer". This PR aims to address this issue.